### PR TITLE
Delayed reset

### DIFF
--- a/Devcade2048/App/Game1.cs
+++ b/Devcade2048/App/Game1.cs
@@ -89,7 +89,7 @@ public class Game1 : Game
 		}
 		Asset.LoseTile[0] = Content.Load<Texture2D>("DED1 Blob");
 		Asset.LoseTile[1] = Content.Load<Texture2D>("DED2 Blob");
-		Asset.Score = Content.Load<SpriteFont>("MonospaceTypewriter");
+		Asset.ScoreFont = Content.Load<SpriteFont>("MonospaceTypewriter");
 
 		Display.Initialize(_spriteBatch, _GameData);
 	}

--- a/Devcade2048/App/Game1.cs
+++ b/Devcade2048/App/Game1.cs
@@ -130,13 +130,15 @@ public class Game1 : Game
 		) {
 			Reset();
 		}
+		if (Animation.ResetGrid()) _GameData.Setup();
 
 		base.Update(gameTime);
 	}
 
 	private void Reset() {
 		HighScoreTracker.Save();
-		switch (_GameData.State) {
+		Animation.BeginReset(_GameData);
+		/*switch (_GameData.State) {
 			case GameState.Continuing:
 			case GameState.Playing:
 			case GameState.InMenu:
@@ -149,7 +151,7 @@ public class Game1 : Game
 				Animation.ChangeStateTo(AnimationState.ResetFromLost);
 				break;
 		}
-		_GameData.Setup();
+		_GameData.Setup(); */
 
 	}
 
@@ -159,9 +161,8 @@ public class Game1 : Game
 	/// <param name="gameTime">This is the gameTime object you can use to get the time since last frame.</param>
 	protected override void Draw(GameTime gameTime)
 	{
+		// System.Console.WriteLine(Animation.State);
 		GraphicsDevice.Clear(new Color(251, 194, 27));
-	 	Animation.Increment(gameTime);
-		ScoreContainer.Increment(gameTime);
 		
 		// Batches all the draw calls for this frame, and then performs them all at once
 		_spriteBatch.Begin();
@@ -179,6 +180,9 @@ public class Game1 : Game
 		else Display.Menu();
 		
 		_spriteBatch.End();
+
+		ScoreContainer.Increment(gameTime);
+	 	Animation.Increment(gameTime);
 
 		base.Draw(gameTime);
 	}

--- a/Devcade2048/App/Manager.cs
+++ b/Devcade2048/App/Manager.cs
@@ -37,7 +37,6 @@ public class Manager {
     }
 
     public void Restart() {
-        // Render.ContinueGame();
         State = GameState.Continuing;
     }
 
@@ -148,7 +147,7 @@ public class Manager {
             }
             if (ScoreDelta > 0) ScoreContainer.Add(ScoreDelta);
 
-			Render.Animation.ChangeStateTo(AnimationState.Moving);
+			Animation.ChangeStateTo(AnimationState.Moving);
             Actuate();
         }
     }

--- a/Devcade2048/App/Render/Animation.cs
+++ b/Devcade2048/App/Render/Animation.cs
@@ -23,6 +23,28 @@ public static class Animation {
         Timer = new TimeSpan();
     }
 
+    public static void BeginReset(Manager man) {
+        if (!AcceptInput()) return;
+        switch (man.State) {
+            case GameState.Won:
+                ChangeStateTo(AnimationState.ResetFromWin);
+                break;
+            case GameState.Lost:
+                ChangeStateTo(AnimationState.ResetFromLost);
+                break;
+            case GameState.Playing:
+            case GameState.Continuing:
+                ChangeStateTo(AnimationState.ResetFromNormal);
+                break;
+            default:
+            // Short circuit the reset animation that means nothing here.
+            // TODO: change it to "Transition to the game". 
+                man.Setup();
+                ChangeStateTo(AnimationState.Spawning);
+                break;
+        }
+    }
+
     public static void Increment(GameTime gt) {
         Timer += gt.ElapsedGameTime;
         JustChanged = false;
@@ -46,6 +68,7 @@ public static class Animation {
             case AnimationState.FromInfo:
             case AnimationState.ResetFromWin:
             case AnimationState.ResetFromLost:
+            case AnimationState.ResetFromNormal:
                 CheckTransitionCompletion();
                 break;
             
@@ -83,6 +106,7 @@ public static class Animation {
             case AnimationState.ToGame:
             case AnimationState.ResetFromWin:
             case AnimationState.ResetFromLost:
+            case AnimationState.ResetFromNormal:
                 State = AnimationState.Spawning;
                 break;
             case AnimationState.FromMenu:
@@ -144,6 +168,7 @@ public static class Animation {
             case AnimationState.FromInfo:
             case AnimationState.ResetFromWin:
             case AnimationState.ResetFromLost:
+            case AnimationState.ResetFromNormal:
                 return Timer / TransitionTime;
 
             case AnimationState.Moving:
@@ -177,11 +202,17 @@ public static class Animation {
 
     public static bool RenderingTiles() {
         return !StateIsAny(
-            AnimationState.ResetFromLost,
             AnimationState.ResetFromWin
         );
     }
 
+    public static bool ResetGrid() {
+        return (
+            State == AnimationState.Spawning 
+         && JustChanged 
+         && StateWasAny(AnimationState.ResetFromWin, AnimationState.ResetFromLost, AnimationState.ResetFromNormal)
+        );
+    }
     public static double Opacity() {
         double percent = PercentComplete();
         switch (State) {

--- a/Devcade2048/App/Render/AnimationState.cs
+++ b/Devcade2048/App/Render/AnimationState.cs
@@ -25,4 +25,5 @@ public enum AnimationState {
     ToLost,
     ResetFromWin, 
     ResetFromLost,
+    ResetFromNormal,
 }

--- a/Devcade2048/App/Render/Asset.cs
+++ b/Devcade2048/App/Render/Asset.cs
@@ -9,5 +9,5 @@ public static class Asset {
     public static Texture2D Grid;
     public static Texture2D[] Tile = new Texture2D[11];
     public static Texture2D[] LoseTile = new Texture2D[2];
-    public static SpriteFont Score;
+    public static SpriteFont ScoreFont;
 }

--- a/Devcade2048/App/Render/Display.cs
+++ b/Devcade2048/App/Render/Display.cs
@@ -47,7 +47,7 @@ public static class Display {
         }
         manager.Grid.EachCell((int _x, int _y, Tile t) => drawWin(t));
         if (Animation.AcceptInput()) {
-            sprite.DrawString(Asset.Score, "YOU WIN!", new Vector2(20, 700), Color.Black);
+            sprite.DrawString(Asset.ScoreFont, "YOU WIN!", new Vector2(20, 700), Color.Black);
         }
     }
 
@@ -60,7 +60,7 @@ public static class Display {
     public static void Lose() {
         if (manager.State != GameState.Lost) return;
         if (Animation.State != AnimationState.WaitingForInput) return;
-        sprite.DrawString(Asset.Score, "GAME OVER!", new Vector2(20, 700), Color.Black);
+        sprite.DrawString(Asset.ScoreFont, "GAME OVER!", new Vector2(20, 700), Color.Black);
     }
 
     private static Texture2D DetermineBlob(Tile t) {
@@ -77,9 +77,9 @@ public static class Display {
 
     public static void Scores() {
 		string scoreStr = "Score: " + manager.Score.ToString().PadLeft(5);
-		int scoreWidth = (int)Asset.Score.MeasureString(scoreStr).X;
+		int scoreWidth = (int)Asset.ScoreFont.MeasureString(scoreStr).X;
 		sprite.DrawString(
-            Asset.Score, 
+            Asset.ScoreFont, 
             scoreStr, 
             new Vector2(400 - scoreWidth, 200), 
             Color.Black
@@ -87,9 +87,9 @@ public static class Display {
 
 		string highScoreStr = 
             "Best: " + HighScoreTracker.HighScore.ToString().PadLeft(5);
-		int highScoreWidth = (int)Asset.Score.MeasureString(highScoreStr).X;
+		int highScoreWidth = (int)Asset.ScoreFont.MeasureString(highScoreStr).X;
 		sprite.DrawString(
-            Asset.Score, 
+            Asset.ScoreFont, 
             highScoreStr, 
             new Vector2(400 - highScoreWidth, 250), 
             Color.Black
@@ -97,10 +97,10 @@ public static class Display {
 
         foreach (ScoreDelta score in ScoreContainer.scores) {
             string deltaStr = "+" + score.ToString();
-            int width = (int) Asset.Score.MeasureString(deltaStr).X;
+            int width = (int) Asset.ScoreFont.MeasureString(deltaStr).X;
             Vector2 position = new Vector2(400 - width, 200 - score.ShiftUp());
             sprite.DrawString(
-                Asset.Score, 
+                Asset.ScoreFont, 
                 deltaStr, 
                 position, 
                 score.DrawColor()

--- a/Devcade2048/App/Render/Display.cs
+++ b/Devcade2048/App/Render/Display.cs
@@ -27,7 +27,7 @@ public static class Display {
                 drawTile(t.MergedFrom[1]);
             }
 
-            Rectangle location = Animation.PositionOfTile(t);
+            Rectangle location = RenderMath.PositionOfTile(t);
 
             Texture2D blob = DetermineBlob(t);
 
@@ -41,7 +41,7 @@ public static class Display {
         if (Animation.UpdatingGrid()) return;
         void drawWin(Tile t) {
             if (t is null || t.Value != 2048) return;
-            Rectangle location = Animation.PositionOfWinTile(t);
+            Rectangle location = RenderMath.PositionOfWinTile(t);
 
             sprite.Draw(Asset.Tile[t.TextureId], location, Color.White);
         }
@@ -53,7 +53,7 @@ public static class Display {
 
     public static void WinReset() {
         if (Animation.State != AnimationState.ResetFromWin) return;
-        Rectangle location = Animation.PositionOfWinTile();
+        Rectangle location = RenderMath.PositionOfWinTile();
         sprite.Draw(Asset.Tile[10], location, Color.White);
     }
 
@@ -65,7 +65,7 @@ public static class Display {
 
     private static Texture2D DetermineBlob(Tile t) {
         if (manager.State != GameState.Lost) return Asset.Tile[t.TextureId];
-        if (t.TextureId > Animation.BiggestLossTile()) return Asset.Tile[t.TextureId];
+        if (t.TextureId > RenderMath.BiggestLossTile()) return Asset.Tile[t.TextureId];
         int loseTileId = 0;
         if (t.TextureId > 5) loseTileId++;
         return Asset.LoseTile[loseTileId];

--- a/Devcade2048/App/Render/RenderMath.cs
+++ b/Devcade2048/App/Render/RenderMath.cs
@@ -23,16 +23,30 @@ public static class RenderMath {
     }
 
     private static int TileScale(Tile t) {
+        if (Animation.StateIsAny(
+            AnimationState.ResetFromLost, 
+            AnimationState.ResetFromNormal
+        )) {
+            return ResetTileScale();
+        }
         if (t.PreviousPosition != null) return 96;
+
         if (Animation.State == AnimationState.Moving) return 0;
         if (Animation.State != AnimationState.Spawning) return 96;
 
         double scaleFactor = Animation.PercentComplete();
+
+
         if (t.MergedFrom is null) return (int) (96 * scaleFactor);
 
         scaleFactor *= 2;
         if (scaleFactor > 1) scaleFactor = (2 - scaleFactor) * 0.25 + 1;
         return (int) (96 * scaleFactor);
+    }
+
+    private static int ResetTileScale() {
+        double scaleFactor = 1 - Animation.PercentComplete();
+        return (int) (96 * scaleFactor * scaleFactor);
     }
 
     private static Vector2 TilePosition(Tile t) {
@@ -51,7 +65,7 @@ public static class RenderMath {
         Vector2 currentPos = TilePosition(t);
         int scale = TileScale(t);
         currentPos += new Vector2(48 - scale/2, 48 - scale/2);
-        
+
         return new Rectangle(
             (int) currentPos.X,
             (int) currentPos.Y,
@@ -93,7 +107,7 @@ public static class RenderMath {
     }
 
     public static int BiggestLossTile() {
-        if (Animation.State == AnimationState.WaitingForInput) return 12;
+        if (Animation.StateIsAny(AnimationState.WaitingForInput, AnimationState.ResetFromLost)) return 12;
         if (Animation.State != AnimationState.ToLost) return -1;
 
         return (int) ((Animation.PercentComplete() - 0.5) * 20);

--- a/Devcade2048/App/Render/RenderMath.cs
+++ b/Devcade2048/App/Render/RenderMath.cs
@@ -1,0 +1,101 @@
+using System;
+using Microsoft.Xna.Framework;
+
+namespace Devcade2048.App.Render;
+
+public static class RenderMath {
+        public static Color TextColorFade(Color c) {
+        int r = 251, g = 194, b = 27;
+        double opacity = Animation.Opacity();
+        r = (int) (c.R * (1 - opacity) + r * opacity);
+        g = (int) (c.G * (1 - opacity) + g * opacity);
+        b = (int) (c.B * (1 - opacity) + b * opacity);
+        return new Color(r, g, b);
+    }
+
+
+    // Tile management
+    private static Vector2 ToScreenPosition(Vector2 pos) {
+        return new Vector2(
+            (int) (12 + pos.X * 100),
+            (int) (292 + pos.Y * 100)
+        );
+    }
+
+    private static int TileScale(Tile t) {
+        if (t.PreviousPosition != null) return 96;
+        if (Animation.State == AnimationState.Moving) return 0;
+        if (Animation.State != AnimationState.Spawning) return 96;
+
+        double scaleFactor = Animation.PercentComplete();
+        if (t.MergedFrom is null) return (int) (96 * scaleFactor);
+
+        scaleFactor *= 2;
+        if (scaleFactor > 1) scaleFactor = (2 - scaleFactor) * 0.25 + 1;
+        return (int) (96 * scaleFactor);
+    }
+
+    private static Vector2 TilePosition(Tile t) {
+        Vector2 currentPos = ToScreenPosition(t.Position);
+        
+        if (Animation.State != AnimationState.Moving) return currentPos;
+        if (t.PreviousPosition is null) return currentPos;
+
+        Vector2 oldPos = ToScreenPosition((Vector2)t.PreviousPosition);
+        float percent = (float) Animation.PercentComplete();
+
+        return oldPos * (1 - percent) + currentPos * percent;
+    }
+
+    public static Rectangle PositionOfTile(Tile t) {
+        Vector2 currentPos = TilePosition(t);
+        int scale = TileScale(t);
+        currentPos += new Vector2(48 - scale/2, 48 - scale/2);
+        
+        return new Rectangle(
+            (int) currentPos.X,
+            (int) currentPos.Y,
+            scale,
+            scale
+        );
+    }
+
+
+    // Win and Loss States
+    private static double WinScale() {
+        if (!Animation.StateIsAny(
+            AnimationState.ToWon, 
+            AnimationState.EasterEgg, 
+            AnimationState.ResetFromWin
+        )) {
+            return 1.0;
+        }
+        if (Animation.State != AnimationState.ResetFromWin) {
+            return Math.Pow(Animation.PercentComplete(), 3);
+        }
+        double percent = 1 - Animation.PercentComplete();
+        return percent * percent * percent;
+    }
+
+    public static Rectangle PositionOfWinTile(Tile t) {
+        int scale = (int) (96 + 304 * WinScale());
+        return new Rectangle(
+            (int) (12 + t.Position.X * 100 * (1 - WinScale())),
+            (int) (292 + t.Position.Y * 100 * (1 - WinScale())),
+            scale,
+            scale
+        );
+    }
+    
+    public static Rectangle PositionOfWinTile() {
+        int scale = (int) (400 * WinScale());
+        return new Rectangle(212 - scale / 2, 492 - scale / 2, scale, scale);
+    }
+
+    public static int BiggestLossTile() {
+        if (Animation.State == AnimationState.WaitingForInput) return 12;
+        if (Animation.State != AnimationState.ToLost) return -1;
+
+        return (int) ((Animation.PercentComplete() - 0.5) * 20);
+    }
+}


### PR DESCRIPTION
I changed how resetting works, so that it occurs indirectly from animation states instead of directly from the player pressing A1. 

- Cleaned up missed `Render.Animation`s from the last pull
- Moved everything that didn't edit the Animation class into a seperate class, `RenderMath`. 
- Added "previous state" information to Animation.
- Changed reset logic to make the game only reset the grid after the "after (end state)" animation finishes, since we need that grid info to render the end state. 
- Changed the name of the Score Font to `ScoreFont`, because it was annoying me. 
- Moved the `Animation` and `ScoreDelta` ticking to the end of animation, to ensure that there isn't a frame where the old grid is visible. 